### PR TITLE
Fix pushing to NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,9 +30,9 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
 
   publish-gpr:
     needs: build


### PR DESCRIPTION
- Use the correct environment variable for the token
- Set the access to public when pushing