### PR TITLE
Configure trusted publishing for NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,6 +23,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -32,4 +35,4 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      - run: npm publish
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary by Sourcery

Configure GitHub Actions workflow for trusted NPM publishing by granting OIDC permissions and enabling provenance generation

CI:
- Add contents read and id-token write permissions to the publish job
- Update npm publish step to include --provenance flag and set access to public