### PR TITLE
provenance is granted but 404 for package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           node-version: 22
           cache: 'yarn'
+          registry-url: https://registry.npmjs.org/
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: npm publish --provenance --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           node-version: 22
           cache: 'yarn'
-          registry-url: https://registry.npmjs.org/
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: npm publish --provenance --access public
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ibutsu/ibutsu-client-javascript.git"
+    "url": "git+https://github.com/ibutsu/ibutsu-client-javascript.git"
   },
   "keywords": [
     "ibutsu",


### PR DESCRIPTION
trying an NPM token with write access

## Summary by Sourcery

Provide NPM auth token in publish workflow and correct repository URL format

Bug Fixes:
- Fix npm publish 404 by supplying NODE_AUTH_TOKEN from secrets

Enhancements:
- Remove custom registry-url step from workflow
- Update package.json repository URL to use git+https format