### PR TITLE
remove npm provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -59,6 +59,6 @@ jobs:
         run: yarn build
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Would rather publish with provenance but am seeing 404s on publish through the pipelines, for a package that is absolutely in the registry.

## Summary by Sourcery

CI:
- Update npm publish GitHub Actions workflow to publish without the --provenance flag to avoid pipeline publish failures.